### PR TITLE
feat: Release 2.0.0

### DIFF
--- a/python/src/setup.py
+++ b/python/src/setup.py
@@ -27,7 +27,7 @@ import setuptools
 # To debug, set DISTUTILS_DEBUG env var to anything.
 setuptools.setup(
     name="GoogleAppEngineMapReduce",
-    version="2.0.0a11",
+    version="2.0.0",
     packages=setuptools.find_packages(),
     author="Google App Engine",
     author_email="app-engine-pipeline-api@googlegroups.com",


### PR DESCRIPTION
Releases version 2.0.0 of GoogleAppEngineMapReduce. This version includes wheel artifacts in the published package.